### PR TITLE
Add Links between GitHub and Heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Rocket-OAuth-GitHub-Demo
 
+[Deployed on Heroku here](https://rocket-oauth-github-demo.herokuapp.com/)
+
 This project followed the [GitHub Rails OAuth Guide](https://developer.github.com/v3/guides/basics-of-authentication/), but in Rust using the Rocket framework. The end result is a simple web application that requests access to a GitHub user's information and displays it.
 
 My goal was to become more familiar with how to use OAuth to create applications that are secure and that don't require direct password management/storage. The application does not concern itself with consuming the actual API beyond getting the user's information, but it would not be too difficult to extend the example to use the token on the authenticated user.

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,5 +6,6 @@
     <body>
         <h1>Log In Via GitHub OAuth</h1>
         <a href="https://github.com/login/oauth/authorize?scope=read:user&client_id={{ client_id }}">Log in</a>
+        <div><a href="https://github.com/amy-keibler/rocket-oauth-github-demo">View the Source on GitHub</a></div>
     </body>
 </html>

--- a/templates/logged_in_index.html
+++ b/templates/logged_in_index.html
@@ -10,5 +10,6 @@
         <div><img width="50px" src="{{ user.user_image }}"></div>
         {%- endif %}
         <div><a href="/logout">Log Out</a></div>
+        <div><a href="https://github.com/amy-keibler/rocket-oauth-github-demo">View the Source on GitHub</a></div>
     </body>
 </html>


### PR DESCRIPTION
Add a link to the README.md to direct users to the Heroku deployment
Add links to the deployed app back to the GitHub repository