### PR TITLE
Add a repositories page to demonstrate usage of the User's Token

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,0 +1,28 @@
+use failure::{bail, Error};
+use reqwest::header::{HeaderMap, HeaderValue, ACCEPT};
+
+use crate::models::{AuthenticatedUser, Repository};
+
+pub fn retrieve_repositories(user: &AuthenticatedUser) -> Result<Vec<Repository>, Error> {
+    let mut headers = HeaderMap::new();
+    headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
+
+    let client = reqwest::Client::builder()
+        .default_headers(headers)
+        .build()?;
+
+    let get_request = client.get("https://api.github.com/user/repos");
+
+    let response = user.send_authenticated_request(get_request);
+    match response {
+        Ok(mut response) => {
+            let repositories: Vec<Repository> = response.json()?;
+            return Ok(repositories);
+        }
+        Err(e) => bail!(
+            "Could not retrieve repositories for {}: {}",
+            user.user_name,
+            e
+        ),
+    }
+}

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,4 +1,5 @@
 use failure::{format_err, Error};
+use reqwest::RequestBuilder;
 use rocket::request::{FromRequest, Outcome, Request};
 use serde::{Deserialize, Serialize};
 
@@ -19,6 +20,15 @@ impl AuthenticatedUser {
             user_image,
         }
     }
+
+    pub fn send_authenticated_request(
+        &self,
+        request: RequestBuilder,
+    ) -> reqwest::Result<reqwest::Response> {
+        request
+            .header("Authorization", String::from("token ") + &self.github_token)
+            .send()
+    }
 }
 
 impl<'a, 'r> FromRequest<'a, 'r> for AuthenticatedUser {
@@ -37,4 +47,10 @@ impl<'a, 'r> FromRequest<'a, 'r> for AuthenticatedUser {
             Err(_) => Outcome::Forward(()),
         }
     }
+}
+
+#[derive(Deserialize, Debug)]
+pub struct Repository {
+    pub full_name: String,
+    pub html_url: String,
 }

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1,7 +1,7 @@
 use askama::Template;
 use std::sync::Arc;
 
-use crate::models::AuthenticatedUser;
+use crate::models::{AuthenticatedUser, Repository};
 
 #[derive(Template)]
 #[template(path = "index.html")]
@@ -13,4 +13,11 @@ pub struct IndexTemplate {
 #[template(path = "logged_in_index.html")]
 pub struct LoggedInIndexTemplate {
     pub user: AuthenticatedUser,
+}
+
+#[derive(Template)]
+#[template(path = "repositories.html")]
+pub struct RepositoriesTemplate {
+    pub user: AuthenticatedUser,
+    pub repositories: Vec<Repository>,
 }

--- a/templates/repositories.html
+++ b/templates/repositories.html
@@ -4,12 +4,15 @@
         <link rel="shortcut icon" type="image/png" href="/favicon.png"/>
     </head>
     <body>
-        <h1>Logged In</h1>
-        <div><strong>Name:</strong> {{ user.user_name }}</div>
-        {% if !user.user_image.is_empty() -%}
-        <div><img width="50px" src="{{ user.user_image }}"></div>
-        {%- endif %}
-        <div><a href="/repositories">View My Repositories</a></div>
+        <h1>{{ user.user_name }}'s Repositories</h1>
+        {% if !repositories.is_empty() %}
+        <ul>
+            {% for repository in repositories %}
+            <li><a href="{{ repository.html_url }}">{{ repository.full_name }}</a></li>
+            {% endfor %}
+        </ul>
+        {% endif %}
+        <div><a href="/">Home</a></div>
         <div><a href="/logout">Log Out</a></div>
         <div><a href="https://github.com/amy-keibler/rocket-oauth-github-demo">View the Source on GitHub</a></div>
     </body>


### PR DESCRIPTION
Make the via the user so that the credentials are kept private and don't leak
into the rest of the application.
Handle unauthorized access to `/repositories` by returning 401 Unauthorized.

Resolves #4 